### PR TITLE
Keyless Codex personas, streaming, defaults, and .chat-hx logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/uchimanajet7/openai-responses-mcp.git"
+    "url": "git+https://github.com/jfontestad/openai-responses-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/uchimanajet7/openai-responses-mcp/issues"
+    "url": "https://github.com/jfontestad/openai-responses-mcp/issues"
   },
-  "homepage": "https://github.com/uchimanajet7/openai-responses-mcp#readme",
+  "homepage": "https://github.com/jfontestad/openai-responses-mcp#readme",
   "keywords": [
     "openai",
     "responses-api",

--- a/scripts/codex-mcp-bridge.js
+++ b/scripts/codex-mcp-bridge.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Content-Length <-> NDJSON bridge for `codex mcp serve`.
+// - Upstream (client -> bridge): Content-Length framed JSON-RPC
+// - Downstream (bridge -> codex): NDJSON (one JSON per line)
+// - Upstream (bridge -> client): Wrap each NDJSON line from codex into Content-Length
+// Usage:
+//   node scripts/codex-mcp-bridge.js
+// Claude Desktop MCP entry can point at this script.
+
+import { spawn } from 'node:child_process';
+
+const BRIDGE_DEBUG = process.env.BRIDGE_DEBUG === '1' || process.env.DEBUG === '1';
+const CODEX = process.env.CODEX_CLI_PATH || 'codex';
+
+function dlog(msg){ if (BRIDGE_DEBUG) process.stderr.write(`[bridge] ${msg}\n`); }
+
+// Launch codex mcp serve (NDJSON over stdio)
+const child = spawn(CODEX, ['mcp','serve'], { stdio: ['pipe','pipe','pipe'] });
+child.on('exit', (code, sig) => {
+  dlog(`codex exited code=${code} sig=${sig || ''}`);
+  try { process.exit(code ?? 1); } catch {}
+});
+child.stderr.on('data', b => process.stderr.write(b));
+
+// Client stdin (Content-Length) -> codex stdin (NDJSON)
+let inBuf = Buffer.alloc(0);
+process.stdin.on('data', chunk => {
+  inBuf = Buffer.concat([inBuf, chunk]);
+  while (true) {
+    // Find header end (CRLFCRLF preferred, allow LFLF)
+    let headerEnd = inBuf.indexOf('\r\n\r\n');
+    let sep = 4;
+    if (headerEnd === -1) {
+      const alt = inBuf.indexOf('\n\n');
+      if (alt !== -1) { headerEnd = alt; sep = 2; }
+    }
+    if (headerEnd === -1) break;
+    const header = inBuf.slice(0, headerEnd).toString('utf8');
+    const m = header.match(/Content-Length:\s*(\d+)/i);
+    if (!m) { inBuf = inBuf.slice(headerEnd + sep); continue; }
+    const len = parseInt(m[1], 10);
+    const bodyStart = headerEnd + sep;
+    const bodyEnd = bodyStart + len;
+    if (inBuf.length < bodyEnd) break; // wait more
+    const json = inBuf.slice(bodyStart, bodyEnd).toString('utf8');
+    inBuf = inBuf.slice(bodyEnd);
+    dlog(`recv framed -> forward line (${len} bytes)`);
+    child.stdin.write(json + '\n', 'utf8');
+  }
+});
+
+// codex stdout (NDJSON) -> client stdout (Content-Length)
+let outBuf = '';
+child.stdout.on('data', chunk => {
+  outBuf += chunk.toString('utf8');
+  while (true) {
+    const lf = outBuf.indexOf('\n');
+    if (lf === -1) break;
+    const line = outBuf.slice(0, lf).trim();
+    outBuf = outBuf.slice(lf + 1);
+    if (!line) continue;
+    const len = Buffer.byteLength(line, 'utf8');
+    dlog(`send line -> framed (${len} bytes)`);
+    process.stdout.write(`Content-Length: ${len}\r\n\r\n` + line, 'utf8');
+  }
+});
+
+process.on('SIGINT', () => { try { child.kill('SIGINT'); } catch {}; process.exit(130); });
+process.on('SIGTERM', () => { try { child.kill('SIGTERM'); } catch {}; process.exit(143); });

--- a/scripts/codex-responses-hub.js
+++ b/scripts/codex-responses-hub.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// MCP Hub: merge Codex MCP and openai-responses-mcp under one stdio server.
+// - Upstream (Claude) <-> Hub: Content-Length framing
+// - Hub <-> Codex: NDJSON lines
+// - Hub <-> Responses MCP: Content-Length framing
+
+import { spawn } from 'node:child_process';
+
+const DEBUG = process.env.HUB_DEBUG === '1' || process.env.DEBUG === '1';
+const CODEX = process.env.CODEX_CLI_PATH || 'codex';
+const RESP_CMD = process.env.RESP_CMD || 'node';
+const RESP_ARGS = process.env.RESP_ARGS ? JSON.parse(process.env.RESP_ARGS) : [
+  new URL('../build/index.js', import.meta.url).pathname,
+  '--stdio'
+];
+
+function dlog(msg){ if (DEBUG) process.stderr.write(`[hub] ${msg}\n`); }
+
+// ---- Helpers: Content-Length framing (client and responses child) ----
+function toFrame(obj){ const s=JSON.stringify(obj); return `Content-Length: ${Buffer.byteLength(s,'utf8')}\r\n\r\n${s}`; }
+function FrameReader(onMessage){
+  let buf = Buffer.alloc(0);
+  return (chunk)=>{
+    buf = Buffer.concat([buf, chunk]);
+    while (true){
+      let headerEnd = buf.indexOf('\r\n\r\n');
+      let sep=4;
+      if (headerEnd===-1){ const alt=buf.indexOf('\n\n'); if (alt!==-1){ headerEnd=alt; sep=2; } }
+      if (headerEnd===-1) break;
+      const header = buf.slice(0, headerEnd).toString('utf8');
+      const m = header.match(/Content-Length:\s*(\d+)/i);
+      if (!m){ buf = buf.slice(headerEnd+sep); continue; }
+      const len = parseInt(m[1],10);
+      const bodyStart = headerEnd+sep; const bodyEnd = bodyStart+len;
+      if (buf.length < bodyEnd) break;
+      const json = buf.slice(bodyStart, bodyEnd).toString('utf8');
+      buf = buf.slice(bodyEnd);
+      try { onMessage(JSON.parse(json)); } catch {}
+    }
+  };
+}
+
+// ---- Children ----
+// Codex MCP server (NDJSON)
+const codex = spawn(CODEX, ['mcp','serve'], { stdio: ['pipe','pipe','pipe'] });
+codex.stderr.on('data', b => process.stderr.write(b));
+let codexOutBuf = '';
+const codexSend = (obj) => { const s = JSON.stringify(obj); dlog(`codex<= ${s}`); codex.stdin.write(s+'\n','utf8'); };
+const codexOnMessageCbs = [];
+codex.stdout.on('data', (chunk)=>{
+  codexOutBuf += chunk.toString('utf8');
+  while (true){
+    const lf = codexOutBuf.indexOf('\n'); if (lf===-1) break;
+    const line = codexOutBuf.slice(0, lf).trim(); codexOutBuf = codexOutBuf.slice(lf+1);
+    if (!line) continue;
+    let msg; try { msg = JSON.parse(line); } catch { continue; }
+    dlog(`codex=> ${line}`);
+    for (const cb of codexOnMessageCbs) cb(msg);
+  }
+});
+
+// Responses MCP child (Content-Length)
+const resp = spawn(RESP_CMD, RESP_ARGS, { stdio: ['pipe','pipe','pipe'] });
+resp.stderr.on('data', b => process.stderr.write(b));
+const respSend = (obj) => { const f = toFrame(obj); dlog(`resp<= ${obj.method || '<result>'}`); resp.stdin.write(f,'utf8'); };
+const respOnMessageCbs = [];
+resp.stdout.on('data', FrameReader((msg)=>{ dlog(`resp=> ${msg.method || msg.id}`); for (const cb of respOnMessageCbs) cb(msg); }));
+
+// ---- Hub state ----
+const toolToChild = new Map(); // toolName -> 'codex' | 'resp'
+const inflight = new Map();    // requestId -> child ('codex' | 'resp')
+let childrenInitialized = false;
+
+function initChildren(){
+  if (childrenInitialized) return;
+  childrenInitialized = true;
+  // Initialize both children with a basic handshake
+  codexSend({ jsonrpc:'2.0', id: 1001, method:'initialize', params:{ protocolVersion:'2025-06-18', capabilities:{} } });
+  respSend({ jsonrpc:'2.0', id: 2001, method:'initialize', params:{ protocolVersion:'2025-06-18', capabilities:{} } });
+}
+
+// Helper to fetch and merge tools from both children
+async function fetchTools() {
+  initChildren();
+  const tools = [];
+  const wait = [];
+  wait.push(new Promise((resolve)=>{
+    const id=1002; const handler=(msg)=>{ if (msg.id===id){ codexOnMessageCbs.splice(codexOnMessageCbs.indexOf(handler),1); if (msg.result?.tools) { for (const t of msg.result.tools){ tools.push({ ...t }); toolToChild.set(t.name,'codex'); } } resolve(); } };
+    codexOnMessageCbs.push(handler);
+    codexSend({ jsonrpc:'2.0', id, method:'tools/list', params:{} });
+  }));
+  wait.push(new Promise((resolve)=>{
+    const id=2002; const handler=(msg)=>{ if (msg.id===id){ respOnMessageCbs.splice(respOnMessageCbs.indexOf(handler),1); if (msg.result?.tools) { for (const t of msg.result.tools){ tools.push({ ...t }); toolToChild.set(t.name,'resp'); } } resolve(); } };
+    respOnMessageCbs.push(handler);
+    respSend({ jsonrpc:'2.0', id, method:'tools/list', params:{} });
+  }));
+  await Promise.all(wait);
+  return tools;
+}
+
+// ---- Upstream (client) handling ----
+process.stdin.on('data', FrameReader(async (msg)=>{
+  const { id, method } = msg;
+  if (method === 'initialize' && id !== undefined){
+    // Initialize children lazily and reply OK
+    initChildren();
+    const result = { protocolVersion:'2025-06-18', capabilities:{ tools:{} }, serverInfo:{ name:'codex-responses-hub', version:'0.1.0' } };
+    process.stdout.write(toFrame({ jsonrpc:'2.0', id, result }),'utf8');
+    return;
+  }
+  if (method === 'tools/list' && id !== undefined){
+    const tools = await fetchTools();
+    process.stdout.write(toFrame({ jsonrpc:'2.0', id, result:{ tools } }), 'utf8');
+    return;
+  }
+  if (method === 'tools/call' && id !== undefined){
+    const name = msg?.params?.name;
+    const child = toolToChild.get(name);
+    inflight.set(id, child);
+    if (child === 'codex'){
+      const handler=(m)=>{ if (m.id===id){ codexOnMessageCbs.splice(codexOnMessageCbs.indexOf(handler),1); process.stdout.write(toFrame({ jsonrpc:'2.0', id, result: m.result, error: m.error })); inflight.delete(id); } };
+      codexOnMessageCbs.push(handler);
+      codexSend({ jsonrpc:'2.0', id, method:'tools/call', params: msg.params });
+      return;
+    }
+    if (child === 'resp'){
+      const handler=(m)=>{ if (m.id===id){ respOnMessageCbs.splice(respOnMessageCbs.indexOf(handler),1); process.stdout.write(toFrame({ jsonrpc:'2.0', id, result: m.result, error: m.error })); inflight.delete(id); } };
+      respOnMessageCbs.push(handler);
+      respSend({ jsonrpc:'2.0', id, method:'tools/call', params: msg.params });
+      return;
+    }
+    // Unknown tool
+    process.stdout.write(toFrame({ jsonrpc:'2.0', id, error:{ code:-32601, message:'Unknown tool' } }));
+    return;
+  }
+  if (method === 'notifications/cancelled'){
+    const rid = msg?.params?.requestId;
+    const child = inflight.get(rid);
+    if (child === 'codex') codexSend({ jsonrpc:'2.0', method:'notifications/cancelled', params: msg.params });
+    if (child === 'resp') respSend({ jsonrpc:'2.0', method:'notifications/cancelled', params: msg.params });
+    return;
+  }
+  if (method === 'ping'){
+    if (id !== undefined) process.stdout.write(toFrame({ jsonrpc:'2.0', id, result:{} }));
+    return;
+  }
+  if (id !== undefined){
+    process.stdout.write(toFrame({ jsonrpc:'2.0', id, error:{ code:-32601, message:'Unknown method' } }));
+  }
+}));
+
+process.on('SIGINT', ()=>{ try{ codex.kill('SIGINT'); resp.kill('SIGINT'); }catch{} process.exit(130); });
+process.on('SIGTERM', ()=>{ try{ codex.kill('SIGTERM'); resp.kill('SIGTERM'); }catch{} process.exit(143); });
+

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -39,7 +39,14 @@ export interface Config {
     };
   };
   search: { defaults: { recency_days: number; max_results: number; domains: string[] } };
-  server: { transport: Transport; debug: boolean; debug_file: string | null; show_config_on_start: boolean };
+  server: { transport: Transport; debug: boolean; debug_file: string | null; show_config_on_start: boolean; expose_answer_tools: boolean };
+  codex_defaults: {
+    sandbox: 'read-only' | 'workspace-write' | 'danger-full-access';
+    approval_policy: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+    timeout_ms: number;
+    json_mode: boolean;
+    skip_git_repo_check: boolean;
+  };
 }
 
 export const defaults: Config = {
@@ -72,5 +79,12 @@ export const defaults: Config = {
     system: { source: "builtin", merge: "replace" }
   },
   search: { defaults: { recency_days: 60, max_results: 5, domains: [] } },
-  server: { transport: "stdio", debug: false, debug_file: null, show_config_on_start: false }
+  server: { transport: "stdio", debug: false, debug_file: null, show_config_on_start: false, expose_answer_tools: true },
+  codex_defaults: {
+    sandbox: 'read-only',
+    approval_policy: 'on-failure',
+    timeout_ms: 15 * 60 * 1000,
+    json_mode: true,
+    skip_git_repo_check: true
+  }
 };

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -73,6 +73,31 @@ function applyEnv(cfg: Config, env: NodeJS.ProcessEnv): Config {
     const n = Number(env.MAX_CITATIONS);
     if (!Number.isNaN(n) && n >= 1 && n <= 10) copy.policy.max_citations = n;
   }
+  // Codex defaults via ENV
+  if (env.CODEX_DEFAULT_SANDBOX) {
+    const v = String(env.CODEX_DEFAULT_SANDBOX);
+    if (['read-only','workspace-write','danger-full-access'].includes(v)) (copy as any).codex_defaults.sandbox = v as any;
+  }
+  if (env.CODEX_DEFAULT_APPROVAL_POLICY) {
+    const v = String(env.CODEX_DEFAULT_APPROVAL_POLICY);
+    if (['untrusted','on-failure','on-request','never'].includes(v)) (copy as any).codex_defaults.approval_policy = v as any;
+  }
+  if (env.CODEX_DEFAULT_TIMEOUT_MS) {
+    const n = Number(env.CODEX_DEFAULT_TIMEOUT_MS);
+    if (!Number.isNaN(n) && n > 0) (copy as any).codex_defaults.timeout_ms = n;
+  }
+  if (env.CODEX_DEFAULT_JSON_MODE !== undefined) {
+    const v = String(env.CODEX_DEFAULT_JSON_MODE).toLowerCase();
+    (copy as any).codex_defaults.json_mode = (v === '1' || v === 'true' || v === 'yes');
+  }
+  if (env.CODEX_DEFAULT_SKIP_GIT_REPO_CHECK !== undefined) {
+    const v = String(env.CODEX_DEFAULT_SKIP_GIT_REPO_CHECK).toLowerCase();
+    (copy as any).codex_defaults.skip_git_repo_check = (v === '1' || v === 'true' || v === 'yes');
+  }
+  if (env.EXPOSE_ANSWER_TOOLS !== undefined) {
+    const v = String(env.EXPOSE_ANSWER_TOOLS).toLowerCase();
+    copy.server.expose_answer_tools = (v === '1' || v === 'true' || v === 'yes');
+  }
   // Unified DEBUG specification:
   // - If `DEBUG` is "1"/"true", then server.debug = true
   // - Otherwise, if non-empty string, then server.debug = true and store value in server.debug_file
@@ -116,7 +141,13 @@ export function loadConfig(opts: LoadOptions): Loaded {
       "SEARCH_MAX_RESULTS",
       "SEARCH_RECENCY_DAYS",
       "MAX_CITATIONS",
-      "DEBUG"
+      "DEBUG",
+      "EXPOSE_ANSWER_TOOLS",
+      "CODEX_DEFAULT_SANDBOX",
+      "CODEX_DEFAULT_APPROVAL_POLICY",
+      "CODEX_DEFAULT_TIMEOUT_MS",
+      "CODEX_DEFAULT_JSON_MODE",
+      "CODEX_DEFAULT_SKIP_GIT_REPO_CHECK"
     ];
     for (const k of keys) if (opts.env[k] !== undefined) envTouched.push(k);
   }

--- a/src/history/store.ts
+++ b/src/history/store.ts
@@ -1,0 +1,17 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+function hxDir(): string {
+  const base = process.env.MCP_CHAT_HX_DIR || join(process.cwd(), '.chat-hx');
+  try { mkdirSync(base, { recursive: true }); } catch {}
+  return base;
+}
+
+export function appendEvent(conversationId: string, event: any) {
+  if (!conversationId) return;
+  const dir = hxDir();
+  const path = join(dir, `${conversationId}.jsonl`);
+  const line = JSON.stringify({ ts: new Date().toISOString(), ...event }) + '\n';
+  try { appendFileSync(path, line, { encoding: 'utf8' }); } catch {}
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,11 @@ async function main() {
       logInfo(`cwd=${process.cwd()}`);
       logInfo(`node=${process.version}`);
     }
+    // Always emit a minimal readiness hint to stderr so users who start the
+    // binary manually understand that stdio mode is waiting for a client.
+    if (!dbgEnabled) {
+      logInfo(`stdio mode ready: waiting for MCP client on stdin (send initialize). Set DEBUG=1 for verbose logs.`);
+    }
     if (showConfigPrinted) {
       logInfo(`show-config printed to stderr (continuing)`);
     }

--- a/src/personas/library.ts
+++ b/src/personas/library.ts
@@ -1,0 +1,74 @@
+export type PersonaSpec = {
+  title: string;
+  instructions: string;
+  defaults?: Record<string, any>;
+};
+
+export const PERSONAS: Record<string, PersonaSpec> = {
+  'lead-data-scientist': {
+    title: 'Lead Data Scientist',
+    instructions: [
+      'You are a Lead Data Scientist. Optimize for clear analytical reasoning, reproducible steps, and pragmatic tradeoffs.',
+      'Prefer Python + pandas/Polars, sklearn, and minimal dependencies. Surface assumptions explicitly.',
+      'When proposing experiments, include metrics and validation plans. Keep outputs concise and actionable.'
+    ].join('\n')
+  },
+  'principal-engineer': {
+    title: 'Principal Engineer',
+    instructions: [
+      'You are a Principal Software Engineer. Optimize for correctness, maintainability, and clarity.',
+      'Prefer small, composable functions; include just enough context to understand why.',
+      'State risks, edge cases, and testing hooks succinctly.'
+    ].join('\n')
+  },
+  'security-analyst': {
+    title: 'Security Analyst',
+    instructions: [
+      'You are a Security Analyst. Focus on threat modeling, misuse cases, and least-privilege guidance.',
+      'Flag unsafe patterns and recommend remediations with short justifications.'
+    ].join('\n')
+  },
+  'sre': {
+    title: 'Site Reliability Engineer',
+    instructions: [
+      'You are an SRE. Optimize for reliability, observability, and fast mean-time-to-recovery.',
+      'Prefer minimal changes with maximal resilience. Provide runbooks and rollback notes.'
+    ].join('\n')
+  },
+  'product-manager': {
+    title: 'Product Manager',
+    instructions: [
+      'You are a Product Manager. Communicate crisply, prioritize user impact, and quantify tradeoffs.',
+      'Favor clear acceptance criteria and measurable success metrics.'
+    ].join('\n')
+  },
+  'qa-lead': {
+    title: 'QA Lead',
+    instructions: [
+      'You are a QA Lead. Emphasize testability, coverage, and reproducibility.',
+      'Propose focused test plans, edge cases, and minimal repros. Prefer structured checklists.'
+    ].join('\n')
+  },
+  'ux-writer': {
+    title: 'UX Writer',
+    instructions: [
+      'You are a UX Writer. Optimize for clarity, brevity, and helpful tone.',
+      'Write for humans first; avoid jargon; prefer active voice and concrete actions.'
+    ].join('\n')
+  },
+  'ux-designer': {
+    title: 'UX Designer',
+    instructions: [
+      'You are a UX Designer. Focus on usability, user flows, and accessible interaction patterns.',
+      'Communicate improvements with simple diagrams or stepwise descriptions when helpful.'
+    ].join('\n')
+  },
+  'data-platform-lead': {
+    title: 'Data Platform Lead',
+    instructions: [
+      'You are a Data Platform Lead. Emphasize scalability, data contracts, lineage, and governance.',
+      'Recommend solutions compatible with modern data stacks and clear SLAs.'
+    ].join('\n')
+  }
+};
+

--- a/src/tools/codex-ai.ts
+++ b/src/tools/codex-ai.ts
@@ -1,0 +1,116 @@
+import { callCodexExec } from './codex-exec.js';
+import { PERSONAS } from '../personas/library.js';
+
+type Thinking = 'low' | 'medium' | 'high';
+
+export type CodexAIInput = {
+  prompt: string;
+  persona?: string;
+  thinking?: Thinking;
+  model?: string;
+  profile?: string;
+  max_output_tokens?: number;
+  temperature?: number;
+  enabled_tools?: string[]; // e.g., ['web-run']
+  conversation_id?: string; // reserved for future multi-turn
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+  approval_policy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+  cwd?: string;
+  timeout_ms?: number;
+  json_mode?: boolean;
+  skip_git_repo_check?: boolean;
+  code_only?: boolean;
+  steps?: boolean;
+};
+
+
+function mkSystemPreface(inp: CodexAIInput): string {
+  const personaKey = (inp.persona || '').toLowerCase();
+  const p = PERSONAS[personaKey];
+  const base = p ? `Persona: ${p.title}\n${p.instructions}` : 'Persona: Generalist Engineer\nBe concise, correct, and pragmatic.';
+  const effort = (inp.thinking || 'high');
+  const effortNote = `Reasoning effort: ${effort}. Present only what’s needed to act.`;
+  const style: string[] = [];
+  if (inp.code_only) style.push('Output code only unless asked otherwise. No prose.');
+  if (inp.steps) style.push('When proposing actions, include a numbered step-by-step list.');
+  return [base, effortNote, 'Do not mention tools or internal flags unless explicitly asked.', ...style].join('\n');
+}
+
+function mapReasoningEffort(thinking?: Thinking) {
+  const v = (thinking || 'high');
+  if (v === 'low' || v === 'medium' || v === 'high') return v;
+  return 'high';
+}
+
+export async function callCodexAI(
+  input: CodexAIInput,
+  signal?: AbortSignal,
+  onEvent?: (ev: any) => void
+) {
+  const system = mkSystemPreface(input);
+  const parts: string[] = [system, '', 'User prompt:', input.prompt];
+  const finalPrompt = parts.join('\n');
+
+  const config: Record<string, any> = {};
+  // Map conceptual knobs to Codex config overrides
+  config.model_reasoning_effort = mapReasoningEffort(input.thinking);
+  // Some models only accept 'detailed' for reasoning summary; use safest value.
+  config.model_reasoning_summary = 'detailed';
+  if (typeof input.max_output_tokens === 'number' && input.max_output_tokens > 0) {
+    config.model_max_output_tokens = input.max_output_tokens;
+  }
+  if (typeof input.temperature === 'number') {
+    config.model_temperature = input.temperature;
+  }
+
+  const search = Array.isArray(input.enabled_tools) && input.enabled_tools.includes('web-run');
+
+  const out = await callCodexExec({
+    prompt: finalPrompt,
+    model: input.model,
+    profile: input.profile,
+    cwd: input.cwd || process.cwd(),
+    sandbox: input.sandbox || 'read-only',
+    approval_policy: input.approval_policy || 'on-failure',
+    full_auto: false, // prefer explicit knobs
+    skip_git_repo_check: input.skip_git_repo_check !== false, // default true
+    json_mode: input.json_mode !== false, // default true
+    // Default to 15 minutes for complex runs unless caller overrides
+    timeout_ms: typeof input.timeout_ms === 'number' ? input.timeout_ms : 15 * 60 * 1000,
+    // best-effort web search toggle; supported as a global flag by some Codex builds
+    // For now, approximate via config; hub users may enable the codex MCP tool that has search baked in.
+    // @ts-ignore reintroduce for codex-exec if supported
+    search: search,
+    config
+  }, signal, onEvent);
+
+  return out;
+}
+
+export const codexAIToolDef = {
+  name: 'codex_ai',
+  description: 'Persona-driven Codex execution with opinionated instructions and tuned settings (keyless).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      prompt: { type: 'string' },
+      persona: { type: 'string' },
+      thinking: { enum: ['low','medium','high'] },
+      model: { type: 'string' },
+      profile: { type: 'string' },
+      max_output_tokens: { type: 'number' },
+      temperature: { type: 'number' },
+      enabled_tools: { type: 'array', items: { type: 'string' } },
+      conversation_id: { type: 'string' },
+      sandbox: { enum: ['read-only','workspace-write','danger-full-access'] },
+      approval_policy: { enum: ['untrusted','on-failure','on-request','never'] },
+      cwd: { type: 'string' },
+      timeout_ms: { type: 'number' },
+      json_mode: { type: 'boolean' },
+      skip_git_repo_check: { type: 'boolean' },
+      code_only: { type: 'boolean' },
+      steps: { type: 'boolean' }
+    },
+    required: ['prompt']
+  }
+} as const;

--- a/src/tools/codex-exec.ts
+++ b/src/tools/codex-exec.ts
@@ -1,0 +1,171 @@
+import { spawn } from "node:child_process";
+
+export type CodexExecInput = {
+  prompt: string;
+  model?: string;
+  profile?: string;
+  cwd?: string;
+  sandbox?: "read-only" | "workspace-write" | "danger-full-access";
+  full_auto?: boolean;
+  skip_git_repo_check?: boolean;
+  approval_policy?: "untrusted" | "on-failure" | "on-request" | "never";
+  json_mode?: boolean;            // When true, use codex --json and return only the final agent message
+  timeout_ms?: number;            // Kill the codex process after this many ms (0/undefined -> no extra timeout)
+  config?: Record<string, any>; // dotted paths -> value
+};
+
+export type CodexEvent =
+  | { type: 'agent_message_delta'; delta: string }
+  | { type: 'agent_message'; message: string }
+  | { type: 'token_count'; info: any }
+  | { type: 'raw'; line: string };
+
+export async function callCodexExec(
+  input: CodexExecInput,
+  signal?: AbortSignal,
+  onEvent?: (ev: CodexEvent) => void
+) {
+  const cmd = process.env.CODEX_CLI_PATH || "codex";
+  const args: string[] = ["exec"];
+
+  if (input.model) args.push("-m", input.model);
+  if (input.profile) args.push("-p", input.profile);
+  if (input.cwd) args.push("-C", input.cwd);
+  // Precedence: explicit sandbox overrides --full-auto convenience
+  if (input.full_auto && !input.sandbox) args.push("--full-auto");
+  if (input.sandbox) args.push("-s", input.sandbox);
+  if (input.skip_git_repo_check) args.push("--skip-git-repo-check");
+  if (input.approval_policy) args.push("-c", `approval_policy=${JSON.stringify(input.approval_policy)}`);
+  if (input.config) {
+    for (const [k, v] of Object.entries(input.config)) {
+      const val = typeof v === "string" ? v : JSON.stringify(v);
+      args.push("-c", `${k}=${val}`);
+    }
+  }
+  // Prompt as trailing argument
+  args.push(input.prompt);
+
+  // Prefer JSONL event mode for lower payloads and faster parsing unless explicitly disabled
+  const jsonMode = input.json_mode !== false; // default true
+  if (jsonMode) args.push("--json");
+
+  const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+
+  let stdout = "";
+  let stderr = "";
+  let stdoutLinesBuf = "";
+  let lastAccumulatedMessage: string | null = null;
+  let lastAccumulatedTokens: any = null;
+  child.stdout.on("data", (b) => {
+    const chunk = b.toString("utf8");
+    if (!jsonMode) { stdout += chunk; return; }
+    stdoutLinesBuf += chunk;
+    // Incremental parse and forward events to onEvent
+    let idx: number;
+    while ((idx = stdoutLinesBuf.indexOf("\n")) !== -1) {
+      const line = stdoutLinesBuf.slice(0, idx).trim();
+      stdoutLinesBuf = stdoutLinesBuf.slice(idx + 1);
+      if (!line) continue;
+      try {
+        const ev = JSON.parse(line);
+        const t = ev?.type || ev?.msg?.type;
+        if (t === 'agent_message_delta') {
+          const d = ev?.delta ?? ev?.msg?.delta;
+          if (typeof d === 'string') {
+            onEvent?.({ type: 'agent_message_delta', delta: d });
+            lastAccumulatedMessage = (lastAccumulatedMessage ?? '') + d;
+          }
+        } else if (t === 'agent_message') {
+          const m = ev?.message ?? ev?.msg?.message;
+          if (typeof m === 'string') {
+            onEvent?.({ type: 'agent_message', message: m });
+            lastAccumulatedMessage = m;
+          }
+        } else if (t === 'token_count') {
+          const info = ev?.info ?? ev?.msg?.info ?? null;
+          onEvent?.({ type: 'token_count', info });
+          if (info) lastAccumulatedTokens = info;
+        } else {
+          onEvent?.({ type: 'raw', line });
+        }
+      } catch {
+        onEvent?.({ type: 'raw', line });
+      }
+    }
+  });
+  child.stderr.on("data", (b) => { stderr += b.toString("utf8"); });
+
+  const killed = new Promise<never>((_, rej) => {
+    if (!signal) return;
+    const onAbort = () => {
+      try { child.kill("SIGTERM"); } catch {}
+      const e: any = new Error("Aborted");
+      e.name = "AbortError";
+      rej(e);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  let to: NodeJS.Timeout | null = null;
+  const finished = new Promise<{ code: number | null }>((resolve) => {
+    child.on("close", (code) => { if (to) clearTimeout(to); resolve({ code }); });
+  });
+  const timeoutBudget = typeof input.timeout_ms === 'number' ? input.timeout_ms : 15_000;
+  if (timeoutBudget > 0) {
+    to = setTimeout(() => { try { child.kill("SIGTERM"); } catch {} }, timeoutBudget);
+  }
+
+  const { code } = await Promise.race([finished, killed]);
+  if (!jsonMode) {
+    return { output: stdout.trim(), stderr: stderr.trim(), code };
+  }
+
+  // Parse JSONL events to extract the final agent message (+ optional token usage)
+  let lastMessage: string | null = lastAccumulatedMessage;
+  let totalTokens: any = lastAccumulatedTokens;
+  const flush = stdoutLinesBuf.split(/\r?\n/);
+  for (const line of flush) {
+    const s = line.trim(); if (!s) continue;
+    try {
+      const ev = JSON.parse(s);
+      const t = ev?.type || ev?.msg?.type;
+      if (t === 'agent_message' && typeof ev?.message === 'string') {
+        lastMessage = ev.message;
+      } else if (t === 'agent_message' && typeof ev?.msg?.message === 'string') {
+        lastMessage = ev.msg.message;
+      } else if (t === 'token_count') {
+        totalTokens = ev?.info?.total_token_usage ?? ev?.total_token_usage ?? null;
+      } else if (t === 'agent_message_delta') {
+        // If streaming deltas only, accumulate them
+        const d = ev?.delta || ev?.msg?.delta;
+        if (typeof d === 'string') lastMessage = (lastMessage ?? '') + d;
+      }
+    } catch {
+      // ignore malformed lines
+    }
+  }
+
+  // Fallback when no structured message found
+  if (!lastMessage) lastMessage = stdoutLinesBuf.trim() || null;
+
+  return { message: lastMessage, tokens: totalTokens, stderr: stderr.trim(), code };
+}
+
+export const codexExecToolDef = {
+  name: "codex_exec",
+  description: "Run a non-interactive Codex session via CLI (no API key required). Useful fallback when OpenAI Responses is unavailable.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      prompt: { type: "string" },
+      model: { type: "string" },
+      profile: { type: "string" },
+      cwd: { type: "string" },
+      search: { type: "boolean" },
+      sandbox: { enum: ["read-only","workspace-write","danger-full-access"] },
+      approval_policy: { enum: ["untrusted","on-failure","on-request","never"] },
+      config: { type: "object", additionalProperties: true }
+    },
+    required: ["prompt"]
+  }
+};

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -49,4 +49,52 @@ export const TOOL_DEFINITIONS = {
       required: ["query"]
     }
   }
+  ,
+  codex_exec: {
+    name: "codex_exec",
+    description: "Run a non-interactive Codex session via CLI (no API key required).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prompt: { type: "string" },
+        model: { type: "string" },
+        profile: { type: "string" },
+        cwd: { type: "string" },
+        sandbox: { enum: ["read-only","workspace-write","danger-full-access"] },
+        full_auto: { type: "boolean" },
+        skip_git_repo_check: { type: "boolean" },
+        approval_policy: { enum: ["untrusted","on-failure","on-request","never"] },
+        json_mode: { type: "boolean" },
+        timeout_ms: { type: "number" },
+        config: { type: "object", additionalProperties: true }
+      },
+      required: ["prompt"]
+    }
+  }
+  ,
+  codex_ai: {
+    name: "codex_ai",
+    description: "Persona-driven Codex execution with tuned instructions (keyless, single-turn).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prompt: { type: "string" },
+        persona: { type: "string" },
+        thinking: { enum: ["low","medium","high"] },
+        model: { type: "string" },
+        profile: { type: "string" },
+        max_output_tokens: { type: "number" },
+        temperature: { type: "number" },
+        enabled_tools: { type: "array", items: { type: "string" } },
+        conversation_id: { type: "string" },
+        sandbox: { enum: ["read-only","workspace-write","danger-full-access"] },
+        approval_policy: { enum: ["untrusted","on-failure","on-request","never"] },
+        cwd: { type: "string" },
+        timeout_ms: { type: "number" },
+        json_mode: { type: "boolean" },
+        skip_git_repo_check: { type: "boolean" }
+      },
+      required: ["prompt"]
+    }
+  }
 } as const;


### PR DESCRIPTION
Adds codex_ai tool, persona registry, filtered streaming via notifications/progress and codex/event, org-wide codex_defaults (sandbox/
  approval/timeout/json/skip-git), and .chat-hx session logging. Improves codex_exec for json_mode, timeouts, and sandbox precedence.